### PR TITLE
fix: more correct return type for getSigningClient

### DIFF
--- a/packages/core/src/wallet-manager.ts
+++ b/packages/core/src/wallet-manager.ts
@@ -1,7 +1,6 @@
 import { AssetList, Chain } from '@chain-registry/types';
 import { getWalletByType } from '@interchain-kit/core';
 import { AminoSigner, CosmosSignerConfig, createCosmosQueryClient, DirectSigner, OfflineSigner } from '@interchainjs/cosmos';
-import { ISigningClient } from '@interchainjs/cosmos/types/signing-client';
 import { HttpEndpoint } from '@interchainjs/types';
 import Bowser from 'bowser';
 import { getSigner } from 'interchainjs';
@@ -247,7 +246,7 @@ export class WalletManager {
     return cosmosWallet.getOfflineSigner(chain.chainId, preferredSignType);
   }
 
-  async getSigningClient(walletName: string, chainName: ChainName): Promise<ISigningClient> {
+  async getSigningClient(walletName: string, chainName: ChainName): Promise<DirectSigner | AminoSigner> {
     try {
       const chain = this.getChainByName(chainName);
       const rpcEndpoint = await this.getRpcEndpoint(walletName, chainName);


### PR DESCRIPTION
`ISigningClient` is too generic and lacks sufficient type information for consumers, leading to poor autocomplete and type checking.

Updated to return concrete `DirectSigner | AminoSigner` types instead of the overly broad `ISigningClient`.

These two are extended from `ISigningClient` so it is fully backward compatible as well.