### PR TITLE
fix: clear states when enabled is set to false in useAsync hook

### DIFF
--- a/packages/react/__tests__/hooks/useAsync.test.ts
+++ b/packages/react/__tests__/hooks/useAsync.test.ts
@@ -127,4 +127,32 @@ describe('useAsync', () => {
     expect(result.current.error).toBeNull();
     expect(queryFn).not.toHaveBeenCalled();
   });
+
+  it('should clear states on enabled change to false', async () => {
+    const queryFn = jest.fn().mockResolvedValue('data');
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useAsync({
+          queryKey: 'test7',
+          queryFn,
+          enabled,
+        }),
+      {
+        initialProps: { enabled: true },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBe('data');
+
+    rerender({ enabled: false });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/packages/react/src/hooks/useAsync.ts
+++ b/packages/react/src/hooks/useAsync.ts
@@ -60,7 +60,14 @@ export function useAsync<T>({
   }, []);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      setState({
+        data: null,
+        isLoading: false,
+        error: null,
+      });
+      return;
+    }
 
     if (!disableCache && cache.has(cacheKey)) {
       setState(prev => ({


### PR DESCRIPTION
This PR prevents accessing `data` when `enabled` is `false` in `useAsync` hook.

For example, currently, `signingClient` from `useSigningClient` remains even after the wallet is disconnected.