### PR TITLE
fix: correct return type of useChain hook

### DIFF
--- a/packages/react/src/types/chain.ts
+++ b/packages/react/src/types/chain.ts
@@ -21,7 +21,7 @@ export type UseChainReturnType = {
   chain: Chain,
   assetList: AssetList,
   address: string,
-  wallet: ChainWalletStore,
+  wallet: ChainWalletStore | undefined,
   rpcEndpoint: string | HttpEndpoint | unknown
   getSigningClient: () => Promise<SigningClient>
 

--- a/packages/store/src/wallet-manager/wallet-manager-store.ts
+++ b/packages/store/src/wallet-manager/wallet-manager-store.ts
@@ -8,6 +8,7 @@ import { createProxiedWallet } from '../proxied-wallets';
 import { InterchainStore } from '../store';
 import { ChainWalletState, InterchainStoreType } from '../types';
 import { LocalStorage } from '../utils/local-storage';
+import type { ChainWalletStore } from './chain-wallet-store';
 import { WalletStore } from './wallet-store';
 export class WalletManagerStore implements WalletManager {
 
@@ -179,7 +180,7 @@ export class WalletManagerStore implements WalletManager {
     this.store.updateChainWalletState(walletName, chainName, data);
   }
 
-  getChainWalletByName(walletName: string, chainName: Chain['chainName']) {
+  getChainWalletByName(walletName: string, chainName: Chain['chainName']): ChainWalletStore | undefined {
     const walletStore = this.wallets.find(w => w.info.name === walletName);
     return walletStore?.getChainWalletStore(chainName);
   }


### PR DESCRIPTION
With current tsconfig (`"strictNullChecks": false`), TS infers return type of `Array.find()` as non-nullable, even though it can return `undefined` at runtime.

This leads type mismatch here:

```ts
const walletStore = this.wallets.find(w => w.info.name === walletName);
```

This returns `undefined` as well.

There are more potential type mismatches of this sort. 
Turning on strictNullChecks would be a more desirable solution in the long term.
