### PR TITLE
fix(core): make CosmosSigningOptions.cosmosSignerConfig partial

### DIFF
--- a/packages/core/src/types/cosmos.ts
+++ b/packages/core/src/types/cosmos.ts
@@ -13,7 +13,7 @@ export interface OfflineDirectSigner {
 }
 
 export interface CosmosSigningOptions {
-  cosmosSignerConfig: CosmosSignerConfig
+  cosmosSignerConfig: Partial<CosmosSignerConfig>
 }
 
 export interface Pubkey {


### PR DESCRIPTION
## Background

 `CosmosSigningOptions.cosmosSignerConfig` was typed as full `CosmosSignerConfig`, but callers may want to only provide `DocOptions` fields (e.g. `gasPrice`, `encodePublicKey`, `pubkeyDecoders`) without `queryClient`, which is injected internally by `getSigningClient()`:

https://github.com/hyperweb-io/interchain-kit/blob/dcdabc86f80ea1be9a25919b755fd8b2b9b931b2/packages/core/src/wallet-manager.ts#L257-L262

## Description

Changed `cosmosSignerConfig` to `Partial<CosmosSignerConfig>` to match actual usage.